### PR TITLE
employees now see all help requests and users only see theirs, delete…

### DIFF
--- a/src/components/apiManager.js
+++ b/src/components/apiManager.js
@@ -72,3 +72,9 @@ export const getUsersHelpRequests = (id) => {
     return fetch(`http://localhost:8088/helpRequests?userId=${id}&_expand=user`)
     .then(res => res.json())
 }
+
+export const employeeCheck = (id) => {
+    return fetch(`http://localhost:8088/users?partner=true&id=${id}`)
+    .then(res => res.json())
+
+}

--- a/src/components/helpRequests/HelpRequest.js
+++ b/src/components/helpRequests/HelpRequest.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react"
-import { deleteHelpRequest, getHelpRequestsWithUser, getUsersHelpRequests } from "../apiManager"
+import { deleteHelpRequest, employeeCheck, getHelpRequestsWithUser, getUsersHelpRequests } from "../apiManager"
 import { HelpRequestForm } from "./HelpRequestForm"
 import "./HelpRequest.css"
 
@@ -9,13 +9,15 @@ export const HelpRequest = () => {
     const [newHelpRequestExists, setNewHelpRequestExists] = useState(false)
     const [helpRequests, setHelpRequests] = useState([])
     const [userHelpRequests, setUserHelpRequests] = useState([])
+    const [e, setE] = useState(false)
+    const [isEmployee, setIsEmployee] = useState([])
 
-    // useEffect(() => {
-    //     getHelpRequestsWithUser()
-    //     .then(setHelpRequests)
+    useEffect(() => {
+        getHelpRequestsWithUser()
+        .then(setHelpRequests)
 
-    // },
-    // [])
+    },
+    [])
 
 
     useEffect(() => {
@@ -25,18 +27,24 @@ export const HelpRequest = () => {
     },
     [])
 
-    const syncHelpRequests = () => {
+    useEffect(() => {
+        employeeCheck(parseInt(localStorage.getItem('code_user')))
+        .then(setIsEmployee)
+
+    },
+    [])
+
+    const syncUsersHelpRequests = () => {
         getUsersHelpRequests(parseInt(localStorage.getItem('code_user')))
         .then(setUserHelpRequests)
     }
 
-    // const filteredHelpRequests = helpRequests.filter()
+    const syncAllHelpRequests = () => {
+        getHelpRequestsWithUser()
+        .then(setHelpRequests)
+    }
 
-
-
-
-
-
+        
     return (
         <>
         <h1>Your help requests</h1>
@@ -45,30 +53,34 @@ export const HelpRequest = () => {
 
             {
                 !!newHelpRequestExists
-                ? <HelpRequestForm newHelpRequestExists={newHelpRequestExists} setNewHelpRequestExists={setNewHelpRequestExists} syncHelpRequests={syncHelpRequests} />
+                ? <HelpRequestForm newHelpRequestExists={newHelpRequestExists} setNewHelpRequestExists={setNewHelpRequestExists} syncHelpRequests={syncUsersHelpRequests} />
                 : ""
             }
 
             {
-                userHelpRequests.map((hr) => {
-                     return <fieldset className="helpRequest">
-                        <div key={hr.id}><h4>Posted by {hr.user.name}</h4>
-                        <h5>Problem descrip: {hr.problemDescription}</h5>
-                        <p>Problem: {hr.problem}</p></div><div><button onClick={() => {
-                            deleteHelpRequest(hr.id)
-                            .then(() => syncHelpRequests())
-                        }}>delete help request</button></div>
-                        </fieldset>
-                        
-                    
-
-
+                
+                !! isEmployee[0]?.partner
+                ? helpRequests.map((hr) => {
+                    return <fieldset className="helpRequest">
+                       <div key={hr.id}><h4>Posted by {hr.user.name}</h4>
+                       <h5>Problem descrip: {hr.problemDescription}</h5>
+                       <p>Problem: {hr.problem}</p></div><div><button onClick={() => {
+                           deleteHelpRequest(hr.id)
+                           .then(() => syncAllHelpRequests())
+                       }}>delete help request</button></div>
+                       </fieldset>
                 })
+                : userHelpRequests.map((hr) => {
+                    return <fieldset className="helpRequest">
+                       <div key={hr.id}><h4>Posted by {hr.user.name}</h4>
+                       <h5>Problem descrip: {hr.problemDescription}</h5>
+                       <p>Problem: {hr.problem}</p></div><div><button onClick={() => {
+                           deleteHelpRequest(hr.id)
+                           .then(() => syncUsersHelpRequests())
+                       }}>delete help request</button></div>
+                       </fieldset>})
             }
-
-
-        
-        
+    
         
         </>
     )

--- a/src/components/helpRequests/HelpRequestForm.js
+++ b/src/components/helpRequests/HelpRequestForm.js
@@ -5,7 +5,6 @@ import { getEmployees, uploadHelpRequest } from "../apiManager"
 
 
 export const HelpRequestForm = ({newHelpRequestExists, setNewHelpRequestExists, syncHelpRequests}) => {
-    // const [newHelpRequestExists, setNewHelpRequestExists] = useState(false)
     const [userHelpRequests, setUserHelpRequests] = useState([])
     const [newHelpRequest, setNewHelpRequest] = useState({})
     const [employees, setEmployees] = useState([])
@@ -81,21 +80,6 @@ export const HelpRequestForm = ({newHelpRequestExists, setNewHelpRequestExists, 
         
 
         }
-
-        {/* {
-            userHelpRequests.map((hr) => {
-                return <fieldset className="help_request">
-                <div key={post.id}><h4>Posted by {post.user.name}</h4>
-                <h5>Problem descrip: {post.problemDescription}</h5>
-                <p>Problem: {post.problem}</p></div>
-                </fieldset>
-
-
-            })
-
-        } */}
-
-
         </>
     )
 }


### PR DESCRIPTION
I added a fetch call to the apiManager, this fetch will return the logged in user's information from the database. I also refactored HelpRequest.js and HelpRequestForm.js to show employees all help requests, and only show the user their own. Users can also delete their help request with an automatic rerender, employees can delete any help request with the same rerender capabilities.