### PR TITLE
Cs employee help request permissions

### DIFF
--- a/src/components/apiManager.js
+++ b/src/components/apiManager.js
@@ -72,3 +72,9 @@ export const getUsersHelpRequests = (id) => {
     return fetch(`http://localhost:8088/helpRequests?userId=${id}&_expand=user`)
     .then(res => res.json())
 }
+
+export const employeeCheck = (id) => {
+    return fetch(`http://localhost:8088/users?partner=true&id=${id}`)
+    .then(res => res.json())
+
+}

--- a/src/components/helpRequests/HelpRequest.js
+++ b/src/components/helpRequests/HelpRequest.js
@@ -34,16 +34,13 @@ export const HelpRequest = () => {
     },
     [])
 
-    const syncUsersHelpRequests = () => {
+    const syncHelpRequests = () => {
         getUsersHelpRequests(parseInt(localStorage.getItem('code_user')))
         .then(setUserHelpRequests)
-    }
 
-    const syncAllHelpRequests = () => {
         getHelpRequestsWithUser()
         .then(setHelpRequests)
     }
-
         
     return (
         <>
@@ -53,7 +50,7 @@ export const HelpRequest = () => {
 
             {
                 !!newHelpRequestExists
-                ? <HelpRequestForm newHelpRequestExists={newHelpRequestExists} setNewHelpRequestExists={setNewHelpRequestExists} syncHelpRequests={syncUsersHelpRequests} />
+                ? <HelpRequestForm newHelpRequestExists={newHelpRequestExists} setNewHelpRequestExists={setNewHelpRequestExists} syncHelpRequests={syncHelpRequests} />
                 : ""
             }
 
@@ -66,7 +63,7 @@ export const HelpRequest = () => {
                        <h5>Problem descrip: {hr.problemDescription}</h5>
                        <p>Problem: {hr.problem}</p></div><div><button onClick={() => {
                            deleteHelpRequest(hr.id)
-                           .then(() => syncAllHelpRequests())
+                           .then(() => syncHelpRequests())
                        }}>delete help request</button></div>
                        </fieldset>
                 })
@@ -76,7 +73,7 @@ export const HelpRequest = () => {
                        <h5>Problem descrip: {hr.problemDescription}</h5>
                        <p>Problem: {hr.problem}</p></div><div><button onClick={() => {
                            deleteHelpRequest(hr.id)
-                           .then(() => syncUsersHelpRequests())
+                           .then(() => syncHelpRequests())
                        }}>delete help request</button></div>
                        </fieldset>})
             }

--- a/src/components/helpRequests/HelpRequest.js
+++ b/src/components/helpRequests/HelpRequest.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react"
-import { deleteHelpRequest, getHelpRequestsWithUser, getUsersHelpRequests } from "../apiManager"
+import { deleteHelpRequest, employeeCheck, getHelpRequestsWithUser, getUsersHelpRequests } from "../apiManager"
 import { HelpRequestForm } from "./HelpRequestForm"
 import "./HelpRequest.css"
 
@@ -9,13 +9,15 @@ export const HelpRequest = () => {
     const [newHelpRequestExists, setNewHelpRequestExists] = useState(false)
     const [helpRequests, setHelpRequests] = useState([])
     const [userHelpRequests, setUserHelpRequests] = useState([])
+    const [e, setE] = useState(false)
+    const [isEmployee, setIsEmployee] = useState([])
 
-    // useEffect(() => {
-    //     getHelpRequestsWithUser()
-    //     .then(setHelpRequests)
+    useEffect(() => {
+        getHelpRequestsWithUser()
+        .then(setHelpRequests)
 
-    // },
-    // [])
+    },
+    [])
 
 
     useEffect(() => {
@@ -25,18 +27,24 @@ export const HelpRequest = () => {
     },
     [])
 
-    const syncHelpRequests = () => {
+    useEffect(() => {
+        employeeCheck(parseInt(localStorage.getItem('code_user')))
+        .then(setIsEmployee)
+
+    },
+    [])
+
+    const syncUsersHelpRequests = () => {
         getUsersHelpRequests(parseInt(localStorage.getItem('code_user')))
         .then(setUserHelpRequests)
     }
 
-    // const filteredHelpRequests = helpRequests.filter()
+    const syncAllHelpRequests = () => {
+        getHelpRequestsWithUser()
+        .then(setHelpRequests)
+    }
 
-
-
-
-
-
+        
     return (
         <>
         <h1>Your help requests</h1>
@@ -45,30 +53,34 @@ export const HelpRequest = () => {
 
             {
                 !!newHelpRequestExists
-                ? <HelpRequestForm newHelpRequestExists={newHelpRequestExists} setNewHelpRequestExists={setNewHelpRequestExists} syncHelpRequests={syncHelpRequests} />
+                ? <HelpRequestForm newHelpRequestExists={newHelpRequestExists} setNewHelpRequestExists={setNewHelpRequestExists} syncHelpRequests={syncUsersHelpRequests} />
                 : ""
             }
 
             {
-                userHelpRequests.map((hr) => {
-                     return <fieldset className="helpRequest">
-                        <div key={hr.id}><h4>Posted by {hr.user.name}</h4>
-                        <h5>Problem descrip: {hr.problemDescription}</h5>
-                        <p>Problem: {hr.problem}</p></div><div><button onClick={() => {
-                            deleteHelpRequest(hr.id)
-                            .then(() => syncHelpRequests())
-                        }}>delete help request</button></div>
-                        </fieldset>
-                        
-                    
-
-
+                
+                !! isEmployee[0]?.partner
+                ? helpRequests.map((hr) => {
+                    return <fieldset className="helpRequest">
+                       <div key={hr.id}><h4>Posted by {hr.user.name}</h4>
+                       <h5>Problem descrip: {hr.problemDescription}</h5>
+                       <p>Problem: {hr.problem}</p></div><div><button onClick={() => {
+                           deleteHelpRequest(hr.id)
+                           .then(() => syncAllHelpRequests())
+                       }}>delete help request</button></div>
+                       </fieldset>
                 })
+                : userHelpRequests.map((hr) => {
+                    return <fieldset className="helpRequest">
+                       <div key={hr.id}><h4>Posted by {hr.user.name}</h4>
+                       <h5>Problem descrip: {hr.problemDescription}</h5>
+                       <p>Problem: {hr.problem}</p></div><div><button onClick={() => {
+                           deleteHelpRequest(hr.id)
+                           .then(() => syncUsersHelpRequests())
+                       }}>delete help request</button></div>
+                       </fieldset>})
             }
-
-
-        
-        
+    
         
         </>
     )

--- a/src/components/helpRequests/HelpRequestForm.js
+++ b/src/components/helpRequests/HelpRequestForm.js
@@ -5,7 +5,6 @@ import { getEmployees, uploadHelpRequest } from "../apiManager"
 
 
 export const HelpRequestForm = ({newHelpRequestExists, setNewHelpRequestExists, syncHelpRequests}) => {
-    // const [newHelpRequestExists, setNewHelpRequestExists] = useState(false)
     const [userHelpRequests, setUserHelpRequests] = useState([])
     const [newHelpRequest, setNewHelpRequest] = useState({})
     const [employees, setEmployees] = useState([])
@@ -81,21 +80,6 @@ export const HelpRequestForm = ({newHelpRequestExists, setNewHelpRequestExists, 
         
 
         }
-
-        {/* {
-            userHelpRequests.map((hr) => {
-                return <fieldset className="help_request">
-                <div key={post.id}><h4>Posted by {post.user.name}</h4>
-                <h5>Problem descrip: {post.problemDescription}</h5>
-                <p>Problem: {post.problem}</p></div>
-                </fieldset>
-
-
-            })
-
-        } */}
-
-
         </>
     )
 }


### PR DESCRIPTION
Users will only see their help requests, they can make a new one as well as delete their own with automatic re-render. Employees will see all help requests and are able to delete them if wanted. The code used to do so can be found in apiManager (fetch call to get logged in user's information from the database), as well as the HelpRequest component (added some code to the syncHelpRequest function, and some ternaries to dictate what information is shown based on who's logged in)