### PR TITLE
help requests, posts, and posts on user profile all show in order fro…

### DIFF
--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -47,14 +47,14 @@ export const Register = (props) => {
             })
     }
 
-    // user being able to hit enter is possible due to onSubmit (keyCode 13)
+    
     const updateCustomer = (evt) => {
         const copy = {...customer}
         copy[evt.target.id] = evt.target.value
         setCustomer(copy)
     }
 
-    // since update customer gets the target.value, you'll need to write a callback funtion onchange of checkbox to setCustomer(copy)
+    
 
     return (
         <main style={{ textAlign: "center" }}>

--- a/src/components/feed/Feed.js
+++ b/src/components/feed/Feed.js
@@ -50,7 +50,7 @@ export const Feed = () => {
                 } */}
                 </fieldset>
 
-            })
+            }).reverse()
 
 
         }

--- a/src/components/helpRequests/HelpRequest.js
+++ b/src/components/helpRequests/HelpRequest.js
@@ -73,7 +73,7 @@ export const HelpRequest = () => {
                            .then(() => syncHelpRequests())
                        }}>delete help request</button></div>
                        </fieldset>
-                })
+                }).reverse()
                 : userHelpRequests.map((hr) => {
                     return <fieldset className="helpRequest">
                        <div key={hr.id}><h4>Posted by {hr.user.name}</h4>
@@ -84,7 +84,7 @@ export const HelpRequest = () => {
                        }}>delete help request</button><button onClick={() => {
                            history.push(`helprequest/${hr.id}`)
                        }}>edit post</button></div>
-                       </fieldset>})
+                       </fieldset>}).reverse()
             }
     
         

--- a/src/components/users/UserProfile.js
+++ b/src/components/users/UserProfile.js
@@ -41,7 +41,7 @@ export const UserProfile = () => {
                     deletePost(post.id)
                     .then(() => {syncPosts()})
                 }}>Delete Post</button></div></fieldset>
-            })
+            }).reverse()
         }
         </>
         


### PR DESCRIPTION
The feed now renders new posts at the top, old at the bottom. This is the same order of the help requests and user profile view. To do this, on any map of a list, I added the .reverse() array method after the map to list the items in descending order. 