### PR TITLE
users now only have to type in feild they want to update

### DIFF
--- a/src/components/helpRequests/EditHelpRequest.js
+++ b/src/components/helpRequests/EditHelpRequest.js
@@ -16,7 +16,12 @@ export const EditHelpRequest = () => {
 
     useEffect(() => {
         
-        fetchEditHelpRequest(hrId).then(setHelpRequest)
+        fetchEditHelpRequest(hrId).then( (data) => {
+            setHelpRequest(data)
+            setUpdatedHelpRequest(data)
+
+        }
+            )
 
     },
     [ hrId ])


### PR DESCRIPTION
When a user wants to edit their help request, they now only have to type in the fields they'd like to change. if a field is left blank, their previous entry will overwrite the blank. This is done by setting the value the state variable responsible for tracking edits to the current post, then if they change a field it will overwrite the existing with their edit. 